### PR TITLE
Yogev/propogate errors

### DIFF
--- a/pkg/drive/drive.go
+++ b/pkg/drive/drive.go
@@ -12,7 +12,8 @@ import (
 )
 
 var (
-	ErrNotSupported = errors.New("operation is not supported")
+	ErrNotSupported       = errors.New("operation is not supported")
+	ErrDeviceNotSupported = errors.New("device is not supported")
 )
 
 type SecurityProtocol int

--- a/pkg/drive/drive_nix.go
+++ b/pkg/drive/drive_nix.go
@@ -5,7 +5,6 @@
 package drive
 
 import (
-	"fmt"
 	"os"
 )
 
@@ -22,5 +21,5 @@ func Open(device string) (DriveIntf, error) {
 	}
 
 	d.Close()
-	return nil, fmt.Errorf("device type not supported")
+	return nil, ErrDeviceNotSupported
 }

--- a/pkg/locking/locking.go
+++ b/pkg/locking/locking.go
@@ -118,7 +118,7 @@ func NewSession(cs *core.ControlSession, lmeta *LockingSPMeta, auth LockingSPAut
 	}
 
 	if err := auth.AuthenticateLockingSP(s, lmeta); err != nil {
-		return nil, fmt.Errorf("authentication failed: %v", err)
+		return nil, err
 	}
 
 	l := &LockingSP{Session: s}

--- a/pkg/locking/locking.go
+++ b/pkg/locking/locking.go
@@ -204,7 +204,7 @@ func Initialize(coreObj *core.Core, opts ...InitializeOpt) (*core.ControlSession
 
 	as, err := cs.NewSession(uid.AdminSP)
 	if err != nil {
-		return nil, nil, fmt.Errorf("admin session creation failed: %v", err)
+		return nil, nil, fmt.Errorf("admin session creation failed: %w", err)
 	}
 	defer as.Close()
 
@@ -219,7 +219,7 @@ func Initialize(coreObj *core.Core, opts ...InitializeOpt) (*core.ControlSession
 		break
 	}
 	if err != nil {
-		return nil, nil, fmt.Errorf("all authentications failed")
+		return nil, nil, fmt.Errorf("all authentications failed: %w", err)
 	}
 
 	if proto == core.ProtocolLevelEnterprise {


### PR DESCRIPTION
As a calling library it is important for us to detect Auth errors in order to avoid device lockup.

By propagating explicit errors it makes it easier to detect these errors.